### PR TITLE
Correction of the header in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 * A Bukkit core lib plugin made by SunShine Technology.
 * [MCBBS发布帖](https://www.mcbbs.net/thread-1170416-1-1.html)
 
-#  # [modules](https://github.com/Sunshine-wzy/SunSTCore/tree/master/src/main/kotlin/io/github/sunshinewzy/sunstcore/modules)  
+## [modules](https://github.com/Sunshine-wzy/SunSTCore/tree/master/src/main/kotlin/io/github/sunshinewzy/sunstcore/modules)  
 模块 - SunSTCore的核心功能
 
 ## [task](https://github.com/Sunshine-wzy/SunSTCore/tree/master/src/main/kotlin/io/github/sunshinewzy/sunstcore/modules/task)


### PR DESCRIPTION
Double '#' with two spaces makes the h2 into a h1